### PR TITLE
Accept region for multi-region deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ Key-value pairs to associate with this stack. This input can be in multiple form
 This action relies on the [default behavior of the AWS SDK for Javascript](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html) to determine AWS credentials and region.
 Use [the `chikin-4x/configure-aws-credentials` action](https://github.com/aws-actions/configure-aws-credentials) to configure the GitHub Actions environment with environment variables containing AWS credentials and your desired region.
 
+
+
+- If you only need to change the region, you can supply that as a parameter:
+```
+    - uses: chikin-4x/aws-cloudformation-github-deploy@master
+      with:
+        name: cloudformation-stack-name
+        template: https://s3.amazonaws.com/some-template.yaml
+        region: us-west-2
+```
+
 We recommend following [Amazon IAM best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) for the AWS credentials used in GitHub Actions workflows, including:
 
 - Do not store credentials in your repository's code. You may use [GitHub Actions secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) to store credentials and redact credentials from GitHub Actions workflow logs.

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: "Whether to enable termination protection on the specified stack. Defaults to '0' (terminated protection will be disabled) This input is only used for stack creation, not for stack update"
     required: false
     default: "0"
+  region:
+    description: "Explicitly set the Region to deploy the CloudFormation stack."
+    required: false
+    default: ""
 outputs:
   stack-id:
     description: "The id of the deployed stack. In addition, any outputs declared in the deployed CloudFormation stack will also be set as outputs for the action, e.g. if the stack has a stack output named 'foo', this action will also have an output named 'foo'."

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,12 +25,25 @@ export type Inputs = {
 }
 
 // The custom client configuration for the CloudFormation clients.
-const clientConfiguration = {
-  customUserAgent: 'aws-cloudformation-github-deploy-for-github-actions'
+const defaultClientConfiguration = {
+  customUserAgent: 'aws-cloudformation-github-deploy-for-github-actions',
+  region: (new aws.Config()).region
 }
 
 export async function run(): Promise<void> {
   try {
+    // If the user provided a region use it, otherwise use the current region
+    const region = core.getInput('region', {
+      required: false
+    })
+    let clientConfiguration = defaultClientConfiguration
+    if (region.length > 0) {
+      clientConfiguration = {
+        customUserAgent: 'aws-cloudformation-github-deploy-for-github-actions',
+        region: region
+      }
+      core.debug('Setting region for cloudformation deployment to ' + region)
+    }
     const cfn = new aws.CloudFormation({ ...clientConfiguration })
     const { GITHUB_WORKSPACE = __dirname } = process.env
 


### PR DESCRIPTION
*Description of changes:

Add a `region` parameter so that actions can more easily deploy templates across multiple regions.  Below is an example that will deploy the stack in three different regions.

`
  deploy-cloudformation:
    name: Deploy cloudformation AWS stacks
    env: ${{ fromJson(needs.init.outputs.env) }} # Setting env to env output from previous job
    needs: init
    runs-on: ${{ needs.init.outputs.account }} # Specifying which runner to run on
    strategy:
      matrix:
        region: ["us-east-1", "us-west-2", "us-east-2"]
    steps:
    - name: Clear workspace
      uses: chick-fil-a/gha-clear-workspace@v1
    - uses: actions/checkout@v2
    - name: Deploy Cloudformation - cloudformation.yaml
      uses: chikin-4x/aws-cloudformation-github-deploy@master
      with:
        name: ${{ env.ENVIRONMENT }}-${{ env.PROJECT_NAME }}
        template: ./${{ env.IAC_DIR }}/cloudformation.yaml
        no-fail-on-empty-changeset: "1"
        capabilities: CAPABILITY_NAMED_IAM
        region: ${{ matrix.region }}
        parameter-overrides: |
          Name: ${{ env.PROJECT_NAME }}
          Environment: ${{ env.ENVIRONMENT }}
        tags: |
          SystemTag: ${{ env.SYSTEM_TAG }}
          Environment: ${{ env.ENVIRONMENT }}
          ALLOW_GHA_DELETE: "TRUE"
`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
